### PR TITLE
fix negative temperature bug

### DIFF
--- a/BME280.cpp
+++ b/BME280.cpp
@@ -115,7 +115,7 @@ void BME280::initialize()
  
 float BME280::getTemperature()
 {
-    uint32_t temp_raw;
+    int32_t temp_raw;
     float tempf;
     char cmd[4];
  


### PR DESCRIPTION
fixes bug that gives wrong temperature values when temperature is below zero.
(the bug is also present in your library on mbed.com)

If the temperature drops below 0°C, the return value of `getTemperature()` flips to values over 400°C.

I just have spend 10+ hours to pinpoint the origin of the bug.